### PR TITLE
Add Authentication and User Attachment to createItem Endpoint

### DIFF
--- a/backend/controllers/itemController.js
+++ b/backend/controllers/itemController.js
@@ -29,14 +29,17 @@ export const getItemById = async (req, res) => {
 
 // Create a new item
 export const createItem = async (req, res) => {
-    const newItem = new ItemModel(req.body)
     try {
-        await newItem.save()
-        res.status(201).json(newItem)
+        const newItemData = req.body;
+        newItemData.donor = req.user.id; // Attach the donor field
+
+        const newItem = new ItemModel(newItemData);
+        await newItem.save();
+        res.status(201).json(newItem);
     } catch (error) {
-        res.status(400).json({ message: error.message })
+        res.status(400).json({ message: error.message });
     }
-}
+};
 
 // Update an existing item
 export const updateItem = async (req, res) => {

--- a/backend/routes/itemRoutes.js
+++ b/backend/routes/itemRoutes.js
@@ -1,12 +1,13 @@
 import express from 'express';
 import { getItems, getItemById, createItem, updateItem, deleteItem } from '../controllers/itemController.js';
+import { authMiddleware } from '../middlewares/authMiddleware.js';
 
 const router = express.Router();
- 
+
 router.get('/items', getItems);
 router.get('/items/:id', getItemById);
-router.post('/items', createItem);
-router.put('/items/:id', updateItem);
-router.delete('/items/:id', deleteItem);
+router.post('/items', authMiddleware, createItem); // Protect this route with authMiddleware
+router.put('/items/:id', authMiddleware, updateItem); // Protect update if only logged-in users can update
+router.delete('/items/:id', authMiddleware, deleteItem); // Protect delete if only logged-in users can delete
 
 export default router;

--- a/frontend/src/components/items/ListItem.js
+++ b/frontend/src/components/items/ListItem.js
@@ -15,7 +15,6 @@ const ListItem = () => {
   const [itemQuantity, setItemQuantity] = useState('')
   const [itemPickupLocation, setItemPickupLocation] = useState('')
   const [itemTags, setItemTags] = useState('')
-  const [itemDonar, setItemDonar] = useState('')
   const [itemStatus, setItemStatus] = useState('')
   const [setItemListedOn] = useState('')
 
@@ -39,7 +38,6 @@ const ListItem = () => {
       setItemQuantity('')
       setItemPickupLocation('')
       setItemTags('')
-      setItemDonar('')
       setItemStatus('')
       setItemListedOn('')
     }
@@ -64,7 +62,6 @@ const ListItem = () => {
       "category": itemCategory,
       "quantity": itemQuantity,
       "tags": itemTags,
-      "donor":  "67170ee76ae1f40b4785e448",
       'pickupLocation': itemPickupLocation
     }
     try {


### PR DESCRIPTION
This PR secures the createItem endpoint by adding user authentication and automatically assigning the authenticated user as the item's donor. Key changes include:

- Protecting the POST /items route with authMiddleware to ensure only logged-in users can create items.
- Updating the createItem controller to use the authenticated user's ID (req.user.id) as the donor field.

This enhancement ensures that all items are associated with the user who created them.